### PR TITLE
NO-ISSUE - Fix `until` when it has a different configuration/timezone

### DIFF
--- a/rust_recurrence_generator/src/headers/c_api.h
+++ b/rust_recurrence_generator/src/headers/c_api.h
@@ -7,6 +7,7 @@
 typedef struct {
     char** strings;
     size_t len;
+    char* error;
 } StringArray;
 
 StringArray* recurrence_generator_generate(const char *rule, const char *after, const char *before);

--- a/rust_recurrence_generator/src/recurrence_generator.rs
+++ b/rust_recurrence_generator/src/recurrence_generator.rs
@@ -29,7 +29,8 @@ impl RecurrenceGenerator {
                     .dates;
                 return Ok(dates);
             }
-            (_, _, _) => return Err(RecurrenceGeneratorError::Parsing),
+            (Ok(_), _, _) => return Err(RecurrenceGeneratorError::Parsing),
+            (Err(error), _, _) => return Err(RecurrenceGeneratorError::RRule(error)),
         }
     }
 
@@ -42,5 +43,6 @@ impl RecurrenceGenerator {
 }
 
 pub enum RecurrenceGeneratorError {
+    RRule(RRuleError),
     Parsing,
 }


### PR DESCRIPTION
We want to be flexible with rules that contain `UNTIL` rules that don't match the configuration of `DTSTART`.

For example, having `UNTIL` as an all day date and `DTSTART` as a regular date should still output results when querying for instances of events.