### PR TITLE
Follow Google behavior for `YEARLY` frequency and `BYMONTHDAY`

### DIFF
--- a/rrule/src/core/rrule.rs
+++ b/rrule/src/core/rrule.rs
@@ -525,6 +525,21 @@ impl RRule<Unvalidated> {
             self.by_week_no.clear();
         }
 
+        if self.freq == Frequency::Yearly {
+            if self.by_month.is_empty() && !self.by_month_day.is_empty() {
+                let month = get_month(dt_start);
+                self.by_month = vec![month];
+            } else if self.by_month_day.is_empty()
+                && self.by_n_month_day.is_empty()
+                && self.by_weekday.is_empty()
+                && self.by_year_day.is_empty()
+                && !self.by_month.is_empty()
+            {
+                let day = get_day(dt_start);
+                self.by_month_day = vec![day];
+            }
+        }
+
         // make sure all BYXXX are unique and sorted
         self.by_hour.sort_unstable();
         self.by_hour.dedup();

--- a/rrule/src/core/rrule.rs
+++ b/rrule/src/core/rrule.rs
@@ -525,6 +525,7 @@ impl RRule<Unvalidated> {
             self.by_week_no.clear();
         }
 
+        // Follow Google behavior for YEARLY frequency and BYMONTHDAY
         if self.freq == Frequency::Yearly {
             if self.by_month.is_empty() && !self.by_month_day.is_empty() {
                 let month = get_month(dt_start);

--- a/rrule/src/tests/regression.rs
+++ b/rrule/src/tests/regression.rs
@@ -625,7 +625,7 @@ fn yearly_by_monthday_and_weekday() {
 }
 
 #[test]
-fn yearly_by_monthday_and_weekday() {
+fn yearly_by_monthday_and_weekday_2() {
     let rrule_set = "DTSTART;TZID=Asia/Kolkata:20240420T080000\nRRULE:FREQ=YEARLY;BYMONTHDAY=1,3;BYDAY=TU,TH;COUNT=5"
         .parse::<RRuleSet>()
         .unwrap();

--- a/rrule/src/tests/regression.rs
+++ b/rrule/src/tests/regression.rs
@@ -509,6 +509,189 @@ fn gmt_tz() {
     common::check_occurrences(&dates, &["2020-11-01T01:00:00+00:00"]);
 }
 
+#[test]
+fn yearly_by_monthday() {
+    let rrule_set = "DTSTART;TZID=Asia/Kolkata:20210420T080000\nRDATE;TZID=Asia/Kolkata:20210420T080000\nRRULE:FREQ=YEARLY;BYMONTHDAY=20"
+        .parse::<RRuleSet>()
+        .unwrap();
+
+    let dates = rrule_set
+        .all(5)
+        .dates;
+
+    common::check_occurrences(&dates, &[
+        "2021-04-20T08:00:00+05:30",
+        "2022-04-20T08:00:00+05:30",
+        "2023-04-20T08:00:00+05:30",
+        "2024-04-20T08:00:00+05:30",
+        "2025-04-20T08:00:00+05:30",
+    ]);
+}
+
+#[test]
+fn monthly_by_monthday() {
+    let rrule_set = "DTSTART;TZID=Asia/Kolkata:20210420T080000\nRDATE;TZID=Asia/Kolkata:20210420T080000\nRRULE:FREQ=MONTHLY;BYMONTHDAY=20"
+        .parse::<RRuleSet>()
+        .unwrap();
+
+    let dates = rrule_set
+        .all(5)
+        .dates;
+
+    common::check_occurrences(&dates, &[
+        "2021-04-20T08:00:00+05:30",
+        "2021-05-20T08:00:00+05:30",
+        "2021-06-20T08:00:00+05:30",
+        "2021-07-20T08:00:00+05:30",
+        "2021-08-20T08:00:00+05:30",
+    ]);
+}
+
+
+#[test]
+fn yearly_by_month() {
+    let rrule_set = "DTSTART;TZID=Asia/Kolkata:20210420T080000\nRDATE;TZID=Asia/Kolkata:20210420T080000\nRRULE:FREQ=YEARLY;BYMONTH=4"
+        .parse::<RRuleSet>()
+        .unwrap();
+
+    let dates = rrule_set
+        .all(5)
+        .dates;
+
+    common::check_occurrences(&dates, &[
+        "2021-04-20T08:00:00+05:30",
+        "2022-04-20T08:00:00+05:30",
+        "2023-04-20T08:00:00+05:30",
+        "2024-04-20T08:00:00+05:30",
+        "2025-04-20T08:00:00+05:30",
+    ]);
+}
+
+#[test]
+fn yearly_by_monthday_multiple() {
+    let rrule_set = "DTSTART;TZID=Asia/Kolkata:20210420T080000\nRDATE;TZID=Asia/Kolkata:20210420T080000\nRRULE:FREQ=YEARLY;BYMONTHDAY=20,30"
+        .parse::<RRuleSet>()
+        .unwrap();
+
+    let dates = rrule_set
+        .all(5)
+        .dates;
+
+    common::check_occurrences(&dates, &[
+        "2021-04-20T08:00:00+05:30",
+        "2021-04-30T08:00:00+05:30",
+        "2022-04-20T08:00:00+05:30",
+        "2022-04-30T08:00:00+05:30",
+        "2023-04-20T08:00:00+05:30",
+    ]);
+}
+
+#[test]
+fn yearly_by_month_multiple() {
+    let rrule_set = "DTSTART;TZID=Asia/Kolkata:20210420T080000\nRDATE;TZID=Asia/Kolkata:20210420T080000\nRRULE:FREQ=YEARLY;BYMONTH=4,6"
+        .parse::<RRuleSet>()
+        .unwrap();
+
+    let dates = rrule_set
+        .all(5)
+        .dates;
+
+    common::check_occurrences(&dates, &[
+        "2021-04-20T08:00:00+05:30",
+        "2021-06-20T08:00:00+05:30",
+        "2022-04-20T08:00:00+05:30",
+        "2022-06-20T08:00:00+05:30",
+        "2023-04-20T08:00:00+05:30",
+    ]);
+}
+
+#[test]
+fn yearly_by_monthday_and_weekday() {
+    let rrule_set = "DTSTART;TZID=Asia/Kolkata:20210420T080000\nRRULE:FREQ=YEARLY;BYMONTHDAY=1,3;BYDAY=TU,TH;COUNT=5"
+        .parse::<RRuleSet>()
+        .unwrap();
+
+    let dates = rrule_set
+        .all(5)
+        .dates;
+
+    common::check_occurrences(&dates, &[
+        "2025-04-01T08:00:00+05:30",
+        "2025-04-03T08:00:00+05:30",
+        "2027-04-01T08:00:00+05:30",
+        "2029-04-03T08:00:00+05:30",
+        "2031-04-01T08:00:00+05:30",
+    ]);
+}
+
+#[test]
+fn yearly_by_monthday_and_weekday() {
+    let rrule_set = "DTSTART;TZID=Asia/Kolkata:20240420T080000\nRRULE:FREQ=YEARLY;BYMONTHDAY=1,3;BYDAY=TU,TH;COUNT=5"
+        .parse::<RRuleSet>()
+        .unwrap();
+
+    let dates = rrule_set
+        .all(5)
+        .dates;
+
+    common::check_occurrences(&dates, &[
+        "2025-04-01T08:00:00+05:30",
+        "2025-04-03T08:00:00+05:30",
+        "2027-04-01T08:00:00+05:30",
+        "2029-04-03T08:00:00+05:30",
+        "2031-04-01T08:00:00+05:30",
+    ]);
+}
+
+
+#[test]
+fn yearly_by_setpos() {
+    let rrule_set = "DTSTART;TZID=Asia/Kolkata:20240420T080000\nRRULE:FREQ=YEARLY;BYMONTHDAY=20;BYSETPOS=3,-3"
+        .parse::<RRuleSet>()
+        .unwrap();
+
+    let dates = rrule_set
+        .all(10)
+        .dates;
+
+    assert_eq!(dates.len(), 0, "List sizes don't match");
+}
+
+#[test]
+fn yearly_by_setpos_2() {
+    let rrule_set = "DTSTART;TZID=Asia/Kolkata:20240420T080000\nRRULE:FREQ=YEARLY;BYMONTHDAY=20,21,22,23;BYSETPOS=2,-2"
+        .parse::<RRuleSet>()
+        .unwrap();
+
+    let dates = rrule_set
+        .all(5)
+        .dates;
+
+    common::check_occurrences(&dates, &[
+        "2024-04-21T08:00:00+05:30",
+        "2024-04-22T08:00:00+05:30",
+        "2025-04-21T08:00:00+05:30",
+        "2025-04-22T08:00:00+05:30",
+        "2026-04-21T08:00:00+05:30",
+    ]);
+}
+
+#[test]
+fn yearly_by_setpos_3() {
+    let rrule_set = "DTSTART;TZID=Asia/Kolkata:20240420T080000\nRRULE:FREQ=MONTHLY;COUNT=3;BYDAY=MO;BYSETPOS=-1"
+        .parse::<RRuleSet>()
+        .unwrap();
+
+    let dates = rrule_set
+        .all(5)
+        .dates;
+
+    common::check_occurrences(&dates, &[
+        "2024-04-29T08:00:00+05:30",
+        "2024-05-27T08:00:00+05:30",
+        "2024-06-24T08:00:00+05:30",
+    ]);
+}
 
 fn with_timezone<F: FnOnce()>(tz: &str, test: F) {
     // Save the current timezone to restore it later

--- a/rrule/src/tests/rrule.rs
+++ b/rrule/src/tests/rrule.rs
@@ -173,28 +173,28 @@ fn yearly_by_month() {
     );
 }
 
-#[test]
-fn yearly_by_monthday() {
-    let rrule = RRule {
-        freq: Frequency::Yearly,
-        count: Some(3),
-        by_hour: vec![9],
-        by_minute: vec![0],
-        by_second: vec![0],
-        by_month_day: vec![1, 3],
-        ..Default::default()
-    };
-    test_recurring_rrule(
-        rrule,
-        true,
-        ymd_hms(1997, 9, 2, 9, 0, 0),
-        &[
-            ymd_hms(1997, 9, 3, 9, 0, 0),
-            ymd_hms(1997, 10, 1, 9, 0, 0),
-            ymd_hms(1997, 10, 3, 9, 0, 0),
-        ],
-    );
-}
+// #[test]
+// fn yearly_by_monthday() {
+//     let rrule = RRule {
+//         freq: Frequency::Yearly,
+//         count: Some(3),
+//         by_hour: vec![9],
+//         by_minute: vec![0],
+//         by_second: vec![0],
+//         by_month_day: vec![1, 3],
+//         ..Default::default()
+//     };
+//     test_recurring_rrule(
+//         rrule,
+//         true,
+//         ymd_hms(1997, 9, 2, 9, 0, 0),
+//         &[
+//             ymd_hms(1997, 9, 3, 9, 0, 0),
+//             ymd_hms(1997, 10, 1, 9, 0, 0),
+//             ymd_hms(1997, 10, 3, 9, 0, 0),
+//         ],
+//     );
+// }
 
 #[test]
 fn yearly_by_month_and_monthday() {
@@ -373,29 +373,29 @@ fn yearly_by_month_and_nweekday_large() {
     );
 }
 
-#[test]
-fn yearly_by_monthday_and_weekday() {
-    let rrule = RRule {
-        freq: Frequency::Yearly,
-        count: Some(3),
-        by_weekday: vec![NWeekday::Every(Weekday::Tue), NWeekday::Every(Weekday::Thu)],
-        by_hour: vec![9],
-        by_minute: vec![0],
-        by_second: vec![0],
-        by_month_day: vec![1, 3],
-        ..Default::default()
-    };
-    test_recurring_rrule(
-        rrule,
-        true,
-        ymd_hms(1997, 9, 2, 9, 0, 0),
-        &[
-            ymd_hms(1998, 1, 1, 9, 0, 0),
-            ymd_hms(1998, 2, 3, 9, 0, 0),
-            ymd_hms(1998, 3, 3, 9, 0, 0),
-        ],
-    );
-}
+// #[test]
+// fn yearly_by_monthday_and_weekday() {
+//     let rrule = RRule {
+//         freq: Frequency::Yearly,
+//         count: Some(3),
+//         by_weekday: vec![NWeekday::Every(Weekday::Tue), NWeekday::Every(Weekday::Thu)],
+//         by_hour: vec![9],
+//         by_minute: vec![0],
+//         by_second: vec![0],
+//         by_month_day: vec![1, 3],
+//         ..Default::default()
+//     };
+//     test_recurring_rrule(
+//         rrule,
+//         true,
+//         ymd_hms(1997, 9, 2, 9, 0, 0),
+//         &[
+//             ymd_hms(1998, 1, 1, 9, 0, 0),
+//             ymd_hms(1998, 2, 3, 9, 0, 0),
+//             ymd_hms(1998, 3, 3, 9, 0, 0),
+//         ],
+//     );
+// }
 
 #[test]
 fn yearly_by_month_and_monthday_and_weekday() {
@@ -782,29 +782,29 @@ fn yearly_by_hour_and_minute_and_second() {
     );
 }
 
-#[test]
-fn yearly_by_setpos() {
-    let rrule = RRule {
-        freq: Frequency::Yearly,
-        count: Some(3),
-        by_hour: vec![6, 18],
-        by_set_pos: vec![3, -3],
-        by_minute: vec![0],
-        by_second: vec![0],
-        by_month_day: vec![15],
-        ..Default::default()
-    };
-    test_recurring_rrule(
-        rrule,
-        true,
-        ymd_hms(1997, 9, 2, 9, 0, 0),
-        &[
-            ymd_hms(1997, 11, 15, 18, 0, 0),
-            ymd_hms(1998, 2, 15, 6, 0, 0),
-            ymd_hms(1998, 11, 15, 18, 0, 0),
-        ],
-    );
-}
+// #[test]
+// fn yearly_by_setpos() {
+//     let rrule = RRule {
+//         freq: Frequency::Yearly,
+//         count: Some(3),
+//         by_hour: vec![6, 18],
+//         by_set_pos: vec![3, -3],
+//         by_minute: vec![0],
+//         by_second: vec![0],
+//         by_month_day: vec![15],
+//         ..Default::default()
+//     };
+//     test_recurring_rrule(
+//         rrule,
+//         true,
+//         ymd_hms(1997, 9, 2, 9, 0, 0),
+//         &[
+//             ymd_hms(1997, 11, 15, 18, 0, 0),
+//             ymd_hms(1998, 2, 15, 6, 0, 0),
+//             ymd_hms(1998, 11, 15, 18, 0, 0),
+//         ],
+//     );
+// }
 
 #[test]
 fn monthly() {


### PR DESCRIPTION
Unfortunately, Rust library generates the wrong occurrences for below rule:

```
DTSTART;TZID=Asia/Kolkata:20210420T080000\nRRULE:FREQ=YEARLY;BYMONTHDAY=20
```

When it expected to be:

```
"2021-04-20T08:00:00+05:30",
"2022-04-20T08:00:00+05:30",
"2023-04-20T08:00:00+05:30",
"2024-04-20T08:00:00+05:30",
"2025-04-20T08:00:00+05:30",
```

It generates:

```
"2021-04-20T08:00:00+05:30",
"2021-05-20T08:00:00+05:30",
"2021-06-20T08:00:00+05:30",
"2021-07-20T08:00:00+05:30",
"2021-08-20T08:00:00+05:30",
```

This PR, changes the behavior to be similar to what Google has.